### PR TITLE
Make sure the generated native libraries are 16kb aligned.

### DIFF
--- a/opusencoder/src/main/cpp/CMakeLists.txt
+++ b/opusencoder/src/main/cpp/CMakeLists.txt
@@ -36,6 +36,15 @@ add_library(opuscodec
         codec/CodecOggOpus.cpp
         opuscodec.cpp)
 
+# Request 16KiB alignment for generated shared objects.
+set(PAGE_ALIGN_FLAG "-Wl,-z,max-page-size=0x4000")
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.13" AND COMMAND target_link_options)
+    target_link_options(opuscodec PRIVATE ${PAGE_ALIGN_FLAG})
+else()
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PAGE_ALIGN_FLAG}")
+endif()
+
 target_include_directories(opuscodec PRIVATE
         ${LIBOPUS_DIR}/include
         ${LIBOPUSENC_DIR}/include)


### PR DESCRIPTION
Make sure the generated native libraries are 16kb aligned. Fixes #7

Generated .so files checked:

```
➜  libopusencoder-android git:(bma/align16k) ✗ /opt/homebrew/opt/llvm/bin/llvm-objdump -p opusencoder/build/outputs/aar/opusencoder-release/jni/arm64-v8a/libopuscodec.so |grep LOAD
    LOAD off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**14
    LOAD off    0x00000000000ad100 vaddr 0x00000000000b1100 paddr 0x00000000000b1100 align 2**14
    LOAD off    0x00000000000b20c0 vaddr 0x00000000000ba0c0 paddr 0x00000000000ba0c0 align 2**14
```

2**14 -> 16kb aligned.