### PR TITLE
Make sure the library can be used by Element Classic and prepare release 1.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.library' version '8.10.0' apply false
-    id 'org.jetbrains.kotlin.android' version '2.1.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
     id 'com.vanniktech.maven.publish' version '0.32.0' apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.useAndroidX=true
 # Ref: https://github.com/vanniktech/gradle-maven-publish-plugin
 GROUP=io.element.android
 POM_ARTIFACT_ID=opusencoder
-VERSION_NAME=1.1.1
+VERSION_NAME=1.1.2
 
 POM_PACKAGING=aar
 

--- a/opusencoder/src/main/cpp/CMakeLists.txt
+++ b/opusencoder/src/main/cpp/CMakeLists.txt
@@ -36,15 +36,6 @@ add_library(opuscodec
         codec/CodecOggOpus.cpp
         opuscodec.cpp)
 
-# Request 16KiB alignment for generated shared objects.
-set(PAGE_ALIGN_FLAG "-Wl,-z,max-page-size=0x4000")
-
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.13" AND COMMAND target_link_options)
-    target_link_options(opuscodec PRIVATE ${PAGE_ALIGN_FLAG})
-else()
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PAGE_ALIGN_FLAG}")
-endif()
-
 target_include_directories(opuscodec PRIVATE
         ${LIBOPUS_DIR}/include
         ${LIBOPUSENC_DIR}/include)


### PR DESCRIPTION
Make sure the library can be used by Element Classic and prepare release 1.1.2

Work in #8 was actually not necessary, I have reverted this commit.
But we need to use a previous version of the Kotlin compiler, else Element Classic cannot be compiled.

I have compiled Element Classic with a local build of this library (aar file): the code is compiling and the library is 16k aligned.

Context: https://github.com/element-hq/element-android/issues/9086